### PR TITLE
Fix Dev UI and Endpoints Card

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/mailpit/deployment/MailpitContainer.java
+++ b/deployment/src/main/java/io/quarkiverse/mailpit/deployment/MailpitContainer.java
@@ -55,8 +55,8 @@ public final class MailpitContainer extends GenericContainer<MailpitContainer> {
      * The dynamic host name determined from TestContainers.
      */
     private String hostName;
-    private IndexView index;
-    private OptionalInt mappedFixedPort;
+    private final IndexView index;
+    private final OptionalInt mappedFixedPort;
 
     MailpitContainer(MailpitConfig config, boolean useSharedNetwork, IndexView index, String path) {
         super(DockerImageName.parse(config.imageName()).asCompatibleSubstituteFor(MailpitConfig.DEFAULT_IMAGE));
@@ -102,6 +102,11 @@ public final class MailpitContainer extends GenericContainer<MailpitContainer> {
         } else {
             addExposedPorts(PORT_SMTP, PORT_HTTP);
         }
+    }
+
+    @Override
+    public String getHost() {
+        return useSharedNetwork ? this.hostName : super.getHost();
     }
 
     /**

--- a/deployment/src/main/java/io/quarkiverse/mailpit/deployment/devui/MailpitDevUIProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/mailpit/deployment/devui/MailpitDevUIProcessor.java
@@ -45,6 +45,7 @@ public class MailpitDevUIProcessor {
         routes.produce(frameworkRoot.routeBuilder()
                 .management()
                 .route(MailpitProcessor.FEATURE + "/*")
+                .displayOnNotFoundPage("Mailpit UI")
                 .handler(recorder.handler(coreVertxBuildItem.getVertx()))
                 .build());
     }
@@ -57,11 +58,6 @@ public class MailpitDevUIProcessor {
             ManagementInterfaceBuildTimeConfig managementInterfaceBuildTimeConfig,
             LaunchModeBuildItem launchModeBuildItem) {
         if (configProps.isPresent()) {
-            var path = nonApplicationRootPathBuildItem.resolveManagementPath(
-                    MailpitProcessor.FEATURE,
-                    managementInterfaceBuildTimeConfig,
-                    launchModeBuildItem);
-
             Map<String, String> config = configProps.get().getConfig();
             final CardPageBuildItem card = new CardPageBuildItem();
 
@@ -77,9 +73,13 @@ public class MailpitDevUIProcessor {
 
             // UI
             if (config.containsKey(MailpitContainer.CONFIG_HTTP_SERVER)) {
+                var externalPath = nonApplicationRootPathBuildItem.resolveManagementPath(
+                        MailpitProcessor.FEATURE,
+                        managementInterfaceBuildTimeConfig,
+                        launchModeBuildItem);
+
                 card.addPage(Page.externalPageBuilder("Mailpit UI")
-                        .doNotEmbed()
-                        .url(path)
+                        .url(externalPath, externalPath)
                         .isHtmlContent()
                         .icon("font-awesome-solid:envelopes-bulk"));
             }


### PR DESCRIPTION
cc @ggrebert 

This fixes the DevUI back to allowing the internal URL and it adds `/q/mailpit` to the Endpoints list.

![image](https://github.com/user-attachments/assets/d07775a0-b4c1-49b2-bd00-e08281fca4a8)
