### PR TITLE
Compress more mailpit logs

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/mailpit/deployment/MailpitProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/mailpit/deployment/MailpitProcessor.java
@@ -2,6 +2,7 @@ package io.quarkiverse.mailpit.deployment;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import org.jboss.jandex.IndexView;
 import org.jboss.logging.Logger;
@@ -33,6 +34,9 @@ public class MailpitProcessor {
     private static final Logger log = Logger.getLogger(MailpitProcessor.class);
 
     public static final String FEATURE = "mailpit";
+
+    private static final Predicate<Thread> IS_DOCKER_JAVA_STREAM_THREAD_PREDICATE = (thread) -> thread.getName()
+            .startsWith("docker-java-stream");
 
     /**
      * Label to add to shared Dev Service for Mailpit running in containers.
@@ -76,7 +80,7 @@ public class MailpitProcessor {
 
         StartupLogCompressor compressor = new StartupLogCompressor(
                 (launchMode.isTest() ? "(test) " : "") + "Mailpit Dev Services Starting:",
-                consoleInstalledBuildItem, loggingSetupBuildItem);
+                consoleInstalledBuildItem, loggingSetupBuildItem, IS_DOCKER_JAVA_STREAM_THREAD_PREDICATE);
         try {
             var path = nonApplicationRootPathBuildItem.resolveManagementPath(
                     MailpitProcessor.FEATURE,


### PR DESCRIPTION
This catches the following (noisy entries)

```posh
2024-07-31 13:35:02,255 INFO  [io.qua.mai.dep.MailpitContainer] (docker-java-stream-1743824167) [mailpit] STDOUT: time="2024/07/31 10:35:02" level=debug msg="[db] using temporary database: /tmp/mailpit-1722422102252869976.db"
2024-07-31 13:35:02,256 INFO  [io.qua.mai.dep.MailpitContainer] (docker-java-stream-1743824167) [mailpit] STDOUT: time="2024/07/31 10:35:02" level=debug msg="[db] applied schema: 1.0.0.sql"
2024-07-31 13:35:02,256 INFO  [io.qua.mai.dep.MailpitContainer] (docker-java-stream-1743824167) [mailpit] STDOUT: time="2024/07/31 10:35:02" level=debug msg="[db] applied schema: 1.1.0.sql"
2024-07-31 13:35:02,257 INFO  [io.qua.mai.dep.MailpitContainer] (docker-java-stream-1743824167) [mailpit] STDOUT: time="2024/07/31 10:35:02" level=debug msg="[db] applied schema: 1.2.0.sql"
2024-07-31 13:35:02,258 INFO  [io.qua.mai.dep.MailpitContainer] (docker-java-stream-1743824167) [mailpit] STDOUT: time="2024/07/31 10:35:02" level=debug msg="[db] applied schema: 1.3.0.sql"
2024-07-31 13:35:02,258 INFO  [io.qua.mai.dep.MailpitContainer] (docker-java-stream-1743824167) [mailpit] STDOUT: time="2024/07/31 10:35:02" level=debug msg="[db] applied schema: 1.4.0.sql"
2024-07-31 13:35:02,258 INFO  [io.qua.mai.dep.MailpitContainer] (docker-java-stream-1743824167) [mailpit] STDOUT: time="2024/07/31 10:35:02" level=debug msg="[db] applied schema: 1.5.0.sql"
2024-07-31 13:35:02,259 INFO  [io.qua.mai.dep.MailpitContainer] (docker-java-stream-1743824167) [mailpit] STDOUT: time="2024/07/31 10:35:02" level=info msg="[smtpd] starting on [::]:1025 (no encryption)"
2024-07-31 13:35:02,259 INFO  [io.qua.mai.dep.MailpitContainer] (docker-java-stream-1743824167) [mailpit] STDOUT: time="2024/07/31 10:35:02" level=info msg="[http] starting on [::]:8025"
2024-07-31 13:35:02,259 INFO  [io.qua.mai.dep.MailpitContainer] (docker-java-stream-1743824167) [mailpit] STDOUT: time="2024/07/31 10:35:02" level=info msg="[http] accessible via http://localhost:8025/q/mailpit/"
```