### PR TITLE
Add Mailpit Chaos Testing flag

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/mailpit/deployment/MailpitConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/mailpit/deployment/MailpitConfig.java
@@ -42,6 +42,12 @@ public interface MailpitConfig {
     boolean verbose();
 
     /**
+     * Flag to control if chaos testing is requested.
+     */
+    @WithDefault("false")
+    boolean enableChaos();
+
+    /**
      * Although mailpit can easily handling tens of thousands of emails, it will automatically prune old messages by default
      * keeping the most recent 500 emails. Default is 500, or set to 0 to disable entirely.
      */
@@ -61,6 +67,9 @@ public interface MailpitConfig {
             return false;
         }
         if (!Objects.equals(d1.verbose(), d2.verbose())) {
+            return false;
+        }
+        if (!Objects.equals(d1.enableChaos(), d2.enableChaos())) {
             return false;
         }
         if (!Objects.equals(d1.maxMessages(), d2.maxMessages())) {

--- a/deployment/src/main/java/io/quarkiverse/mailpit/deployment/MailpitContainer.java
+++ b/deployment/src/main/java/io/quarkiverse/mailpit/deployment/MailpitContainer.java
@@ -77,6 +77,11 @@ public final class MailpitContainer extends GenericContainer<MailpitContainer> {
             super.withEnv("MP_VERBOSE", "true");
         }
 
+        // configure chaos testing
+        if (config.enableChaos()) {
+            super.withEnv("MP_ENABLE_CHAOS", "true");
+        }
+
         // max messages
         super.withEnv("MP_MAX_MESSAGES", Objects.toString(config.maxMessages()));
 

--- a/docs/modules/ROOT/pages/includes/quarkus-mailpit.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mailpit.adoc
@@ -60,6 +60,22 @@ endif::add-copy-button-to-env-var[]
 --|boolean 
 |`true`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-mailpit_quarkus-mailpit-enable-chaos]]`link:#quarkus-mailpit_quarkus-mailpit-enable-chaos[quarkus.mailpit.enable-chaos]`
+
+
+[.description]
+--
+Flag to control if chaos testing is requested.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MAILPIT_ENABLE_CHAOS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MAILPIT_ENABLE_CHAOS+++`
+endif::add-copy-button-to-env-var[]
+--|boolean
+|`false`
+
 
 a|icon:lock[title=Fixed at build time] [[quarkus-mailpit_quarkus-mailpit-max-messages]]`link:#quarkus-mailpit_quarkus-mailpit-max-messages[quarkus.mailpit.max-messages]`
 


### PR DESCRIPTION
As of Mailpit v1.20.0 there is a [chaos testing feature](https://mailpit.axllent.org/docs/integration/chaos/).

This allows you to inject faults when sending an email to Mailpit and useful for testing error conditions.

This PR adds a configuration flag for the chaos testing feature and sets the correct environment variable for the docker container.

Upon testing this feature I found that PUT requests (and any request with a http body in the request)  were not working via the mailpit ui proxy.


Consider the following curl request:

```
curl -X PUT "http://localhost:8080/q/mailpit/api/v1/chaos" \
 -H 'accept: application/json'\
 -H 'content-type: application/json' \
 -d '{"Authentication":{"ErrorCode":451,"Probability":5},"Recipient":{"ErrorCode":451,"Probability":5},"Sender":{"ErrorCode":451,"Probability":5}}' 
```

The expected result was either returning the payload that it was set to or if the feature was not enabled "Chaos is not enabled" but instead the curl command would hang.

This was due to the MailpitUiProxy class not consuming the http body of the original request - this was working OK for GET requests because they have no body.

I used [event.request().body() ](https://github.com/eclipse-vertx/vert.x/blob/master/vertx-core/src/main/java/io/vertx/core/http/HttpServerRequest.java#L290) which may consume a large amount of memory on a large payload.
 
