### PR TITLE
OpenAPI spec update to version v1.21.8

### DIFF
--- a/testing/src/conf/openapi.json
+++ b/testing/src/conf/openapi.json
@@ -50,7 +50,7 @@
     },
     "/api/v1/message/{ID}": {
       "get": {
-        "description": "Returns the summary of a message, marking the message as read.",
+        "description": "Returns the summary of a message, marking the message as read.\n\nThe ID can be set to `latest` to return the latest message.",
         "produces": [
           "application/json"
         ],
@@ -66,7 +66,7 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Message database ID",
+            "description": "Message database ID or \"latest\"",
             "name": "ID",
             "in": "path",
             "required": true
@@ -87,7 +87,7 @@
     },
     "/api/v1/message/{ID}/headers": {
       "get": {
-        "description": "Returns the message headers as an array.",
+        "description": "Returns the message headers as an array.\n\nThe ID can be set to `latest` to return the latest message headers.",
         "produces": [
           "application/json"
         ],
@@ -103,7 +103,7 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Database ID",
+            "description": "Message database ID or \"latest\"",
             "name": "ID",
             "in": "path",
             "required": true
@@ -140,7 +140,7 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Message database ID",
+            "description": "Message database ID or \"latest\"",
             "name": "ID",
             "in": "path",
             "required": true
@@ -177,7 +177,7 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Message database ID",
+            "description": "Message database ID or \"latest\"",
             "name": "ID",
             "in": "path",
             "required": true
@@ -290,7 +290,7 @@
     },
     "/api/v1/message/{ID}/raw": {
       "get": {
-        "description": "Returns the full email source as plain text.",
+        "description": "Returns the full email source as plain text.\n\nThe ID can be set to `latest` to return the latest message source.",
         "produces": [
           "text/plain"
         ],
@@ -306,7 +306,7 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Database ID",
+            "description": "Message database ID or \"latest\"",
             "name": "ID",
             "in": "path",
             "required": true
@@ -359,6 +359,43 @@
         "responses": {
           "200": {
             "$ref": "#/responses/OKResponse"
+          },
+          "default": {
+            "$ref": "#/responses/ErrorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/message/{ID}/sa-check": {
+      "get": {
+        "description": "Returns the SpamAssassin (if enabled) summary of the message.\n\nNOTE: This feature is currently in beta and is documented for reference only.\nPlease do not integrate with it (yet) as there may be changes.",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "Other"
+        ],
+        "summary": "SpamAssassin check (beta)",
+        "operationId": "SpamAssassinCheck",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Message database ID or \"latest\"",
+            "name": "ID",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "SpamAssassinResponse",
+            "schema": {
+              "$ref": "#/definitions/SpamAssassinResponse"
+            }
           },
           "default": {
             "$ref": "#/responses/ErrorResponse"
@@ -571,7 +608,7 @@
           "tags"
         ],
         "summary": "Get all current tags",
-        "operationId": "GetTags",
+        "operationId": "GetAllTags",
         "responses": {
           "200": {
             "$ref": "#/responses/ArrayResponse"
@@ -727,7 +764,7 @@
       "x-go-package": "net/mail"
     },
     "AppInformation": {
-      "description": "Response includes the current and latest Mailpit version, database info, and memory usage",
+      "description": "AppInformation struct",
       "type": "object",
       "properties": {
         "Database": {
@@ -743,12 +780,61 @@
           "description": "Latest Mailpit version",
           "type": "string"
         },
-        "Memory": {
-          "description": "Current memory usage in bytes",
-          "type": "integer",
-          "format": "uint64"
-        },
         "Messages": {
+          "description": "Total number of messages in the database",
+          "type": "integer",
+          "format": "int64"
+        },
+        "RuntimeStats": {
+          "description": "Runtime statistics",
+          "type": "object",
+          "properties": {
+            "Memory": {
+              "description": "Current memory usage in bytes",
+              "type": "integer",
+              "format": "uint64"
+            },
+            "MessagesDeleted": {
+              "description": "Database runtime messages deleted",
+              "type": "integer",
+              "format": "int64"
+            },
+            "SMTPAccepted": {
+              "description": "Accepted runtime SMTP messages",
+              "type": "integer",
+              "format": "int64"
+            },
+            "SMTPAcceptedSize": {
+              "description": "Total runtime accepted messages size in bytes",
+              "type": "integer",
+              "format": "int64"
+            },
+            "SMTPIgnored": {
+              "description": "Ignored runtime SMTP messages (when using --ignore-duplicate-ids)",
+              "type": "integer",
+              "format": "int64"
+            },
+            "SMTPRejected": {
+              "description": "Rejected runtime SMTP messages",
+              "type": "integer",
+              "format": "int64"
+            },
+            "Uptime": {
+              "description": "Mailpit server uptime in seconds",
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        },
+        "Tags": {
+          "description": "Tags and message totals per tag",
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "Unread": {
           "description": "Total number of messages in the database",
           "type": "integer",
           "format": "int64"
@@ -758,8 +844,7 @@
           "type": "string"
         }
       },
-      "x-go-name": "appInformation",
-      "x-go-package": "github.com/axllent/mailpit/server/apiv1"
+      "x-go-package": "github.com/axllent/mailpit/internal/stats"
     },
     "Attachment": {
       "description": "Attachment struct for inline and attachments",
@@ -808,11 +893,6 @@
       },
       "x-go-name": "deleteMessagesRequestBody",
       "x-go-package": "github.com/axllent/mailpit/server/apiv1"
-    },
-    "File": {
-      "type": "object",
-      "title": "File represents an open file descriptor.",
-      "x-go-package": "os"
     },
     "HTMLCheckResponse": {
       "description": "Response represents the HTML check response struct",
@@ -1179,6 +1259,13 @@
           "description": "Read status",
           "type": "boolean"
         },
+        "ReplyTo": {
+          "description": "Reply-To address",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Address"
+          }
+        },
         "Size": {
           "description": "Message size in bytes (total)",
           "type": "integer",
@@ -1256,6 +1343,54 @@
       },
       "x-go-package": "github.com/axllent/mailpit/server/apiv1"
     },
+    "Rule": {
+      "description": "Rule struct",
+      "type": "object",
+      "properties": {
+        "Description": {
+          "description": "SpamAssassin rule description",
+          "type": "string"
+        },
+        "Name": {
+          "description": "SpamAssassin rule name",
+          "type": "string"
+        },
+        "Score": {
+          "description": "Spam rule score",
+          "type": "number",
+          "format": "double"
+        }
+      },
+      "x-go-package": "github.com/axllent/mailpit/internal/spamassassin"
+    },
+    "SpamAssassinResponse": {
+      "description": "Result is a SpamAssassin result",
+      "type": "object",
+      "properties": {
+        "Error": {
+          "description": "If populated will return an error string",
+          "type": "string"
+        },
+        "IsSpam": {
+          "description": "Whether the message is spam or not",
+          "type": "boolean"
+        },
+        "Rules": {
+          "description": "Spam rules triggered",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Rule"
+          }
+        },
+        "Score": {
+          "description": "Total spam score based on triggered rules",
+          "type": "number",
+          "format": "double"
+        }
+      },
+      "x-go-name": "Result",
+      "x-go-package": "github.com/axllent/mailpit/internal/spamassassin"
+    },
     "WebUIConfiguration": {
       "description": "Response includes global web UI settings",
       "type": "object",
@@ -1264,17 +1399,21 @@
           "description": "Whether the HTML check has been globally disabled",
           "type": "boolean"
         },
+        "DuplicatesIgnored": {
+          "description": "Whether messages with duplicate IDs are ignored",
+          "type": "boolean"
+        },
         "MessageRelay": {
           "description": "Message Relay information",
           "type": "object",
           "properties": {
+            "AllowedRecipients": {
+              "description": "Only allow relaying to these recipients (regex)",
+              "type": "string"
+            },
             "Enabled": {
               "description": "Whether message relaying (release) is enabled",
               "type": "boolean"
-            },
-            "RecipientAllowlist": {
-              "description": "Allowlist of accepted recipients",
-              "type": "string"
             },
             "ReturnPath": {
               "description": "Enforced Return-Path (if set) for relay bounces",
@@ -1285,6 +1424,10 @@
               "type": "string"
             }
           }
+        },
+        "SpamAssassin": {
+          "description": "Whether SpamAssassin is enabled",
+          "type": "boolean"
         }
       },
       "x-go-name": "webUIConfiguration",
@@ -1387,11 +1530,11 @@
     "BinaryResponse": {
       "description": "Binary data response inherits the attachment's content type",
       "schema": {
-        "$ref": "#/definitions/File"
+        "type": "string"
       }
     },
     "ErrorResponse": {
-      "description": "Error response",
+      "description": "HTTP error response will return with a \u003e= 400 response code",
       "schema": {
         "type": "string"
       }

--- a/testing/src/conf/openapi.json
+++ b/testing/src/conf/openapi.json
@@ -124,7 +124,7 @@
     },
     "/api/v1/message/{ID}/html-check": {
       "get": {
-        "description": "Returns the summary of the message HTML checker.\n\nNOTE: This feature is currently in beta and is documented for reference only.\nPlease do not integrate with it (yet) as there may be changes.",
+        "description": "Returns the summary of the message HTML checker.",
         "produces": [
           "application/json"
         ],
@@ -135,7 +135,7 @@
         "tags": [
           "Other"
         ],
-        "summary": "HTML check (beta)",
+        "summary": "HTML check",
         "operationId": "HTMLCheck",
         "parameters": [
           {
@@ -161,7 +161,7 @@
     },
     "/api/v1/message/{ID}/link-check": {
       "get": {
-        "description": "Returns the summary of the message Link checker.\n\nNOTE: This feature is currently in beta and is documented for reference only.\nPlease do not integrate with it (yet) as there may be changes.",
+        "description": "Returns the summary of the message Link checker.",
         "produces": [
           "application/json"
         ],
@@ -172,7 +172,7 @@
         "tags": [
           "Other"
         ],
-        "summary": "Link check (beta)",
+        "summary": "Link check",
         "operationId": "LinkCheck",
         "parameters": [
           {
@@ -368,7 +368,7 @@
     },
     "/api/v1/message/{ID}/sa-check": {
       "get": {
-        "description": "Returns the SpamAssassin (if enabled) summary of the message.\n\nNOTE: This feature is currently in beta and is documented for reference only.\nPlease do not integrate with it (yet) as there may be changes.",
+        "description": "Returns the SpamAssassin summary (if enabled) of the message.",
         "produces": [
           "application/json"
         ],
@@ -379,7 +379,7 @@
         "tags": [
           "Other"
         ],
-        "summary": "SpamAssassin check (beta)",
+        "summary": "SpamAssassin check",
         "operationId": "SpamAssassinCheck",
         "parameters": [
           {
@@ -516,7 +516,7 @@
     },
     "/api/v1/search": {
       "get": {
-        "description": "Returns the latest messages matching a search.",
+        "description": "Returns messages matching [a search](https://mailpit.axllent.org/docs/usage/search-filters/), sorted by received date (descending).",
         "produces": [
           "application/json"
         ],
@@ -553,7 +553,7 @@
           },
           {
             "type": "string",
-            "description": "Timezone for `before:` \u0026 `after:` queries, eg: \"Pacific/Auckland\"",
+            "description": "[Timezone identifier](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) used specifically for `before:` \u0026 `after:` searches (eg: \"Pacific/Auckland\").",
             "name": "tz",
             "in": "query"
           }
@@ -568,7 +568,7 @@
         }
       },
       "delete": {
-        "description": "Delete all messages matching a search.",
+        "description": "Delete all messages matching [a search](https://mailpit.axllent.org/docs/usage/search-filters/).",
         "produces": [
           "application/json"
         ],
@@ -588,6 +588,12 @@
             "name": "query",
             "in": "query",
             "required": true
+          },
+          {
+            "type": "string",
+            "description": "[Timezone identifier](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) used specifically for `before:` \u0026 `after:` searches (eg: \"Pacific/Auckland\").",
+            "name": "tz",
+            "in": "query"
           }
         ],
         "responses": {
@@ -596,6 +602,43 @@
           },
           "default": {
             "$ref": "#/responses/ErrorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/send": {
+      "post": {
+        "description": "Send a message via the HTTP API.",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "message"
+        ],
+        "summary": "Send a message",
+        "operationId": "SendMessage",
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/SendRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/sendMessageResponse"
+          },
+          "default": {
+            "$ref": "#/responses/jsonErrorResponse"
           }
         }
       }
@@ -648,6 +691,79 @@
             "schema": {
               "$ref": "#/definitions/setTagsRequestBody"
             }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/OKResponse"
+          },
+          "default": {
+            "$ref": "#/responses/ErrorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/tags/{tag}": {
+      "put": {
+        "description": "Renames a tag.",
+        "produces": [
+          "text/plain"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "tags"
+        ],
+        "summary": "Rename a tag",
+        "operationId": "RenameTag",
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/renameTagRequestBody"
+            }
+          },
+          {
+            "type": "string",
+            "description": "The url-encoded tag name to rename",
+            "name": "tag",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/OKResponse"
+          },
+          "default": {
+            "$ref": "#/responses/ErrorResponse"
+          }
+        }
+      },
+      "delete": {
+        "description": "Deletes a tag. This will not delete any messages with this tag.",
+        "produces": [
+          "text/plain"
+        ],
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "tags"
+        ],
+        "summary": "Delete a tag",
+        "operationId": "DeleteTag",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "The url-encoded tag name to delete",
+            "name": "tag",
+            "in": "path",
+            "required": true
           }
         ],
         "responses": {
@@ -884,13 +1000,12 @@
       "description": "Delete request",
       "type": "object",
       "properties": {
-        "ids": {
+        "IDs": {
           "description": "Array of message database IDs",
           "type": "array",
           "items": {
             "type": "string"
           },
-          "x-go-name": "IDs",
           "example": [
             "5dec4247-812e-4b77-9101-e25ad406e9ea",
             "8ac66bbc-2d9a-4c41-ad99-00aa75fa674e"
@@ -1076,6 +1191,18 @@
       },
       "x-go-name": "Warning",
       "x-go-package": "github.com/axllent/mailpit/internal/htmlcheck"
+    },
+    "JSONErrorMessage": {
+      "description": "JSONErrorMessage struct",
+      "type": "object",
+      "properties": {
+        "Error": {
+          "description": "Error message",
+          "type": "string",
+          "example": "invalid format"
+        }
+      },
+      "x-go-package": "github.com/axllent/mailpit/server/apiv1"
     },
     "Link": {
       "description": "Link struct",
@@ -1369,6 +1496,182 @@
       },
       "x-go-package": "github.com/axllent/mailpit/internal/spamassassin"
     },
+    "SendMessageConfirmation": {
+      "description": "SendMessageConfirmation struct",
+      "type": "object",
+      "properties": {
+        "ID": {
+          "description": "Database ID",
+          "type": "string",
+          "example": "iAfZVVe2UQFNSG5BAjgYwa"
+        }
+      },
+      "x-go-package": "github.com/axllent/mailpit/server/apiv1"
+    },
+    "SendRequest": {
+      "description": "SendRequest to send a message via HTTP",
+      "type": "object",
+      "required": [
+        "From"
+      ],
+      "properties": {
+        "Attachments": {
+          "description": "Attachments",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "Content",
+              "Filename"
+            ],
+            "properties": {
+              "Content": {
+                "description": "Base64-encoded string of the file content",
+                "type": "string",
+                "example": "VGhpcyBpcyBhIHBsYWluIHRleHQgYXR0YWNobWVudA=="
+              },
+              "Filename": {
+                "description": "Filename",
+                "type": "string",
+                "example": "AttachedFile.txt"
+              }
+            }
+          }
+        },
+        "Bcc": {
+          "description": "Bcc recipients email addresses only",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "example": [
+            "jack@example.com"
+          ]
+        },
+        "Cc": {
+          "description": "Cc recipients",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "Email"
+            ],
+            "properties": {
+              "Email": {
+                "description": "Email address",
+                "type": "string",
+                "example": "manager@example.com"
+              },
+              "Name": {
+                "description": "Optional name",
+                "type": "string",
+                "example": "Manager"
+              }
+            }
+          }
+        },
+        "From": {
+          "description": "\"From\" recipient",
+          "type": "object",
+          "required": [
+            "Email"
+          ],
+          "properties": {
+            "Email": {
+              "description": "Email address",
+              "type": "string",
+              "example": "john@example.com"
+            },
+            "Name": {
+              "description": "Optional name",
+              "type": "string",
+              "example": "John Doe"
+            }
+          }
+        },
+        "HTML": {
+          "description": "Message body (HTML)",
+          "type": "string",
+          "example": "\u003cp style=\"font-family: arial\"\u003eMailpit is \u003cb\u003eawesome\u003c/b\u003e!\u003c/p\u003e"
+        },
+        "Headers": {
+          "description": "Optional headers in {\"key\":\"value\"} format",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "example": {
+            "X-IP": "1.2.3.4"
+          }
+        },
+        "ReplyTo": {
+          "description": "Optional Reply-To recipients",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "Email"
+            ],
+            "properties": {
+              "Email": {
+                "description": "Email address",
+                "type": "string",
+                "example": "secretary@example.com"
+              },
+              "Name": {
+                "description": "Optional name",
+                "type": "string",
+                "example": "Secretary"
+              }
+            }
+          }
+        },
+        "Subject": {
+          "description": "Subject",
+          "type": "string",
+          "example": "Mailpit message via the HTTP API"
+        },
+        "Tags": {
+          "description": "Mailpit tags",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "example": [
+            "Tag 1",
+            "Tag 2"
+          ]
+        },
+        "Text": {
+          "description": "Message body (text)",
+          "type": "string",
+          "example": "This is the text body"
+        },
+        "To": {
+          "description": "\"To\" recipients",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "Email"
+            ],
+            "properties": {
+              "Email": {
+                "description": "Email address",
+                "type": "string",
+                "example": "jane@example.com"
+              },
+              "Name": {
+                "description": "Optional name",
+                "type": "string",
+                "example": "Jane Doe"
+              }
+            }
+          }
+        }
+      },
+      "x-go-package": "github.com/axllent/mailpit/server/apiv1"
+    },
     "SpamAssassinResponse": {
       "description": "Result is a SpamAssassin result",
       "type": "object",
@@ -1401,13 +1704,13 @@
       "description": "Response includes global web UI settings",
       "type": "object",
       "properties": {
-        "DisableHTMLCheck": {
-          "description": "Whether the HTML check has been globally disabled",
-          "type": "boolean"
-        },
         "DuplicatesIgnored": {
           "description": "Whether messages with duplicate IDs are ignored",
           "type": "boolean"
+        },
+        "Label": {
+          "description": "Optional label to identify this Mailpit instance",
+          "type": "string"
         },
         "MessageRelay": {
           "description": "Message Relay information",
@@ -1415,6 +1718,10 @@
           "properties": {
             "AllowedRecipients": {
               "description": "Only allow relaying to these recipients (regex)",
+              "type": "string"
+            },
+            "BlockedRecipients": {
+              "description": "Block relaying to these recipients (regex)",
               "type": "string"
             },
             "Enabled": {
@@ -1443,16 +1750,15 @@
       "description": "Release request",
       "type": "object",
       "required": [
-        "to"
+        "To"
       ],
       "properties": {
-        "to": {
+        "To": {
           "description": "Array of email addresses to relay the message to",
           "type": "array",
           "items": {
             "type": "string"
           },
-          "x-go-name": "To",
           "example": [
             "user1@example.com",
             "user2@example.com"
@@ -1461,27 +1767,40 @@
       },
       "x-go-package": "github.com/axllent/mailpit/server/apiv1"
     },
+    "renameTagRequestBody": {
+      "description": "Rename tag request",
+      "type": "object",
+      "required": [
+        "Name"
+      ],
+      "properties": {
+        "Name": {
+          "description": "New name",
+          "type": "string",
+          "example": "New name"
+        }
+      },
+      "x-go-package": "github.com/axllent/mailpit/server/apiv1"
+    },
     "setReadStatusRequestBody": {
       "description": "Set read status request",
       "type": "object",
       "properties": {
-        "ids": {
+        "IDs": {
           "description": "Array of message database IDs",
           "type": "array",
           "items": {
             "type": "string"
           },
-          "x-go-name": "IDs",
           "example": [
             "5dec4247-812e-4b77-9101-e25ad406e9ea",
             "8ac66bbc-2d9a-4c41-ad99-00aa75fa674e"
           ]
         },
-        "read": {
+        "Read": {
           "description": "Read status",
           "type": "boolean",
           "default": false,
-          "x-go-name": "Read",
           "example": true
         }
       },
@@ -1491,29 +1810,27 @@
       "description": "Set tags request",
       "type": "object",
       "required": [
-        "tags",
-        "ids"
+        "Tags",
+        "IDs"
       ],
       "properties": {
-        "ids": {
+        "IDs": {
           "description": "Array of message database IDs",
           "type": "array",
           "items": {
             "type": "string"
           },
-          "x-go-name": "IDs",
           "example": [
             "5dec4247-812e-4b77-9101-e25ad406e9ea",
             "8ac66bbc-2d9a-4c41-ad99-00aa75fa674e"
           ]
         },
-        "tags": {
+        "Tags": {
           "description": "Array of tag names to set",
           "type": "array",
           "items": {
             "type": "string"
           },
-          "x-go-name": "Tags",
           "example": [
             "Tag 1",
             "Tag 2"
@@ -1534,7 +1851,7 @@
       }
     },
     "BinaryResponse": {
-      "description": "Binary data response inherits the attachment's content type",
+      "description": "Binary data response inherits the attachment's content type.",
       "schema": {
         "type": "string"
       }
@@ -1579,6 +1896,18 @@
       "description": "Web UI configuration",
       "schema": {
         "$ref": "#/definitions/WebUIConfiguration"
+      }
+    },
+    "jsonErrorResponse": {
+      "description": "JSON error response",
+      "schema": {
+        "$ref": "#/definitions/JSONErrorMessage"
+      }
+    },
+    "sendMessageResponse": {
+      "description": "Confirmation message for HTTP send API",
+      "schema": {
+        "$ref": "#/definitions/SendMessageConfirmation"
       }
     }
   }

--- a/testing/src/conf/openapi.json
+++ b/testing/src/conf/openapi.json
@@ -66,7 +66,7 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Database ID",
+            "description": "Message database ID",
             "name": "ID",
             "in": "path",
             "required": true
@@ -136,11 +136,11 @@
           "Other"
         ],
         "summary": "HTML check (beta)",
-        "operationId": "HTMLCheckResponse",
+        "operationId": "HTMLCheck",
         "parameters": [
           {
             "type": "string",
-            "description": "Database ID",
+            "description": "Message database ID",
             "name": "ID",
             "in": "path",
             "required": true
@@ -173,18 +173,19 @@
           "Other"
         ],
         "summary": "Link check (beta)",
-        "operationId": "LinkCheckResponse",
+        "operationId": "LinkCheck",
         "parameters": [
           {
             "type": "string",
-            "description": "Database ID",
+            "description": "Message database ID",
             "name": "ID",
             "in": "path",
             "required": true
           },
           {
-            "type": "boolean",
-            "default": false,
+            "type": "string",
+            "default": "false",
+            "x-go-name": "Follow",
             "description": "Follow redirects",
             "name": "follow",
             "in": "query"
@@ -223,7 +224,7 @@
         "parameters": [
           {
             "type": "string",
-            "description": "Database ID",
+            "description": "Message database ID",
             "name": "ID",
             "in": "path",
             "required": true
@@ -323,7 +324,7 @@
     },
     "/api/v1/message/{ID}/release": {
       "post": {
-        "description": "Release a message via a pre-configured external SMTP server..",
+        "description": "Release a message via a pre-configured external SMTP server. This is only enabled if message relaying has been configured.",
         "consumes": [
           "application/json"
         ],
@@ -338,24 +339,20 @@
           "message"
         ],
         "summary": "Release message",
-        "operationId": "Release",
+        "operationId": "ReleaseMessage",
         "parameters": [
           {
             "type": "string",
-            "description": "Database ID",
+            "description": "Message database ID",
             "name": "ID",
             "in": "path",
             "required": true
           },
           {
-            "description": "Array of email addresses to release message to",
-            "name": "to",
+            "name": "Body",
             "in": "body",
-            "required": true,
             "schema": {
-              "description": "Array of email addresses to release message to",
-              "type": "object",
-              "$ref": "#/definitions/ReleaseMessageRequest"
+              "$ref": "#/definitions/releaseMessageRequestBody"
             }
           }
         ],
@@ -428,13 +425,10 @@
         "operationId": "SetReadStatus",
         "parameters": [
           {
-            "description": "Database IDs to update",
-            "name": "ids",
+            "name": "Body",
             "in": "body",
             "schema": {
-              "description": "Database IDs to update",
-              "type": "object",
-              "$ref": "#/definitions/SetReadStatusRequest"
+              "$ref": "#/definitions/setReadStatusRequestBody"
             }
           }
         ],
@@ -448,7 +442,7 @@
         }
       },
       "delete": {
-        "description": "If no IDs are provided then all messages are deleted.",
+        "description": "Delete individual or all messages. If no IDs are provided then all messages are deleted.",
         "consumes": [
           "application/json"
         ],
@@ -463,15 +457,12 @@
           "messages"
         ],
         "summary": "Delete messages",
-        "operationId": "Delete",
+        "operationId": "DeleteMessages",
         "parameters": [
           {
-            "description": "Database IDs to delete",
-            "name": "ids",
+            "name": "Body",
             "in": "body",
             "schema": {
-              "description": "Database IDs to delete",
-              "type": "object",
               "$ref": "#/definitions/DeleteRequest"
             }
           }
@@ -534,7 +525,7 @@
         }
       },
       "delete": {
-        "description": "Deletes messages matching a search.",
+        "description": "Delete all messages matching a search.",
         "produces": [
           "application/json"
         ],
@@ -546,7 +537,7 @@
           "messages"
         ],
         "summary": "Delete messages by search",
-        "operationId": "MessagesSummary",
+        "operationId": "DeleteSearch",
         "parameters": [
           {
             "type": "string",
@@ -580,7 +571,7 @@
           "tags"
         ],
         "summary": "Get all current tags",
-        "operationId": "SetTags",
+        "operationId": "GetTags",
         "responses": {
           "200": {
             "$ref": "#/responses/ArrayResponse"
@@ -591,7 +582,7 @@
         }
       },
       "put": {
-        "description": "To remove all tags from a message, pass an empty tags array.",
+        "description": "This will overwrite any existing tags for selected message database IDs. To remove all tags from a message, pass an empty tags array.",
         "consumes": [
           "application/json"
         ],
@@ -609,14 +600,10 @@
         "operationId": "SetTags",
         "parameters": [
           {
-            "description": "Database IDs to update",
-            "name": "ids",
+            "name": "Body",
             "in": "body",
-            "required": true,
             "schema": {
-              "description": "Database IDs to update",
-              "type": "object",
-              "$ref": "#/definitions/SetTagsRequest"
+              "$ref": "#/definitions/setTagsRequestBody"
             }
           }
         ],
@@ -807,16 +794,25 @@
       "type": "object",
       "properties": {
         "ids": {
-          "description": "ids\nin:body",
+          "description": "Array of message database IDs",
           "type": "array",
           "items": {
             "type": "string"
           },
-          "x-go-name": "IDs"
+          "x-go-name": "IDs",
+          "example": [
+            "5dec4247-812e-4b77-9101-e25ad406e9ea",
+            "8ac66bbc-2d9a-4c41-ad99-00aa75fa674e"
+          ]
         }
       },
-      "x-go-name": "deleteRequest",
+      "x-go-name": "deleteMessagesRequestBody",
       "x-go-package": "github.com/axllent/mailpit/server/apiv1"
+    },
+    "File": {
+      "type": "object",
+      "title": "File represents an open file descriptor.",
+      "x-go-package": "os"
     },
     "HTMLCheckResponse": {
       "description": "Response represents the HTML check response struct",
@@ -1188,6 +1184,10 @@
           "type": "integer",
           "format": "int64"
         },
+        "Snippet": {
+          "description": "Message snippet includes up to 250 characters",
+          "type": "string"
+        },
         "Subject": {
           "description": "Email subject",
           "type": "string"
@@ -1214,7 +1214,7 @@
       "type": "object",
       "properties": {
         "messages": {
-          "description": "Messages summary\nin:body",
+          "description": "Messages summary\nin: body",
           "type": "array",
           "items": {
             "$ref": "#/definitions/MessageSummary"
@@ -1256,67 +1256,6 @@
       },
       "x-go-package": "github.com/axllent/mailpit/server/apiv1"
     },
-    "ReleaseMessageRequest": {
-      "description": "Release request",
-      "type": "object",
-      "properties": {
-        "to": {
-          "description": "To\nin:body",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "To"
-        }
-      },
-      "x-go-name": "releaseMessageRequest",
-      "x-go-package": "github.com/axllent/mailpit/server/apiv1"
-    },
-    "SetReadStatusRequest": {
-      "description": "Set read status request",
-      "type": "object",
-      "properties": {
-        "ids": {
-          "description": "ids\nin:body",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "IDs"
-        },
-        "read": {
-          "description": "Read status",
-          "type": "boolean",
-          "x-go-name": "Read"
-        }
-      },
-      "x-go-name": "setReadStatusRequest",
-      "x-go-package": "github.com/axllent/mailpit/server/apiv1"
-    },
-    "SetTagsRequest": {
-      "description": "Set tags request",
-      "type": "object",
-      "properties": {
-        "ids": {
-          "description": "IDs\nin:body",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "IDs"
-        },
-        "tags": {
-          "description": "Tags\nin:body",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "x-go-name": "Tags"
-        }
-      },
-      "x-go-name": "setTagsRequest",
-      "x-go-package": "github.com/axllent/mailpit/server/apiv1"
-    },
     "WebUIConfiguration": {
       "description": "Response includes global web UI settings",
       "type": "object",
@@ -1350,6 +1289,89 @@
       },
       "x-go-name": "webUIConfiguration",
       "x-go-package": "github.com/axllent/mailpit/server/apiv1"
+    },
+    "releaseMessageRequestBody": {
+      "description": "Release request",
+      "type": "object",
+      "required": [
+        "to"
+      ],
+      "properties": {
+        "to": {
+          "description": "Array of email addresses to relay the message to",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "To",
+          "example": [
+            "user1@example.com",
+            "user2@example.com"
+          ]
+        }
+      },
+      "x-go-package": "github.com/axllent/mailpit/server/apiv1"
+    },
+    "setReadStatusRequestBody": {
+      "description": "Set read status request",
+      "type": "object",
+      "properties": {
+        "ids": {
+          "description": "Array of message database IDs",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "IDs",
+          "example": [
+            "5dec4247-812e-4b77-9101-e25ad406e9ea",
+            "8ac66bbc-2d9a-4c41-ad99-00aa75fa674e"
+          ]
+        },
+        "read": {
+          "description": "Read status",
+          "type": "boolean",
+          "default": false,
+          "x-go-name": "Read",
+          "example": true
+        }
+      },
+      "x-go-package": "github.com/axllent/mailpit/server/apiv1"
+    },
+    "setTagsRequestBody": {
+      "description": "Set tags request",
+      "type": "object",
+      "required": [
+        "tags",
+        "ids"
+      ],
+      "properties": {
+        "ids": {
+          "description": "Array of message database IDs",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "IDs",
+          "example": [
+            "5dec4247-812e-4b77-9101-e25ad406e9ea",
+            "8ac66bbc-2d9a-4c41-ad99-00aa75fa674e"
+          ]
+        },
+        "tags": {
+          "description": "Array of tag names to set",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "Tags",
+          "example": [
+            "Tag 1",
+            "Tag 2"
+          ]
+        }
+      },
+      "x-go-package": "github.com/axllent/mailpit/server/apiv1"
     }
   },
   "responses": {
@@ -1363,23 +1385,27 @@
       }
     },
     "BinaryResponse": {
-      "description": "Binary data response inherits the attachment's content type"
+      "description": "Binary data response inherits the attachment's content type",
+      "schema": {
+        "$ref": "#/definitions/File"
+      }
     },
     "ErrorResponse": {
-      "description": "Error response"
+      "description": "Error response",
+      "schema": {
+        "type": "string"
+      }
     },
     "HTMLResponse": {
-      "description": "HTML response"
+      "description": "HTML response",
+      "schema": {
+        "type": "string"
+      }
     },
     "InfoResponse": {
       "description": "Application information",
       "schema": {
         "$ref": "#/definitions/AppInformation"
-      },
-      "headers": {
-        "Body": {
-          "description": "Application information"
-        }
       }
     },
     "MessagesSummaryResponse": {
@@ -1389,20 +1415,21 @@
       }
     },
     "OKResponse": {
-      "description": "Plain text \"ok\" response"
+      "description": "Plain text \"ok\" response",
+      "schema": {
+        "type": "string"
+      }
     },
     "TextResponse": {
-      "description": "Plain text response"
+      "description": "Plain text response",
+      "schema": {
+        "type": "string"
+      }
     },
     "WebUIConfigurationResponse": {
       "description": "Web UI configuration",
       "schema": {
         "$ref": "#/definitions/WebUIConfiguration"
-      },
-      "headers": {
-        "Body": {
-          "description": "Web UI configuration settings"
-        }
       }
     }
   }

--- a/testing/src/conf/openapi.json
+++ b/testing/src/conf/openapi.json
@@ -550,6 +550,12 @@
             "description": "Limit results",
             "name": "limit",
             "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Timezone for `before:` \u0026 `after:` queries, eg: \"Pacific/Auckland\"",
+            "name": "tz",
+            "in": "query"
           }
         ],
         "responses": {
@@ -773,8 +779,8 @@
         },
         "DatabaseSize": {
           "description": "Database size in bytes",
-          "type": "integer",
-          "format": "int64"
+          "type": "number",
+          "format": "double"
         },
         "LatestVersion": {
           "description": "Latest Mailpit version",
@@ -782,8 +788,8 @@
         },
         "Messages": {
           "description": "Total number of messages in the database",
-          "type": "integer",
-          "format": "int64"
+          "type": "number",
+          "format": "double"
         },
         "RuntimeStats": {
           "description": "Runtime statistics",
@@ -796,33 +802,33 @@
             },
             "MessagesDeleted": {
               "description": "Database runtime messages deleted",
-              "type": "integer",
-              "format": "int64"
+              "type": "number",
+              "format": "double"
             },
             "SMTPAccepted": {
               "description": "Accepted runtime SMTP messages",
-              "type": "integer",
-              "format": "int64"
+              "type": "number",
+              "format": "double"
             },
             "SMTPAcceptedSize": {
               "description": "Total runtime accepted messages size in bytes",
-              "type": "integer",
-              "format": "int64"
+              "type": "number",
+              "format": "double"
             },
             "SMTPIgnored": {
               "description": "Ignored runtime SMTP messages (when using --ignore-duplicate-ids)",
-              "type": "integer",
-              "format": "int64"
+              "type": "number",
+              "format": "double"
             },
             "SMTPRejected": {
               "description": "Rejected runtime SMTP messages",
-              "type": "integer",
-              "format": "int64"
+              "type": "number",
+              "format": "double"
             },
             "Uptime": {
               "description": "Mailpit server uptime in seconds",
-              "type": "integer",
-              "format": "int64"
+              "type": "number",
+              "format": "double"
             }
           }
         },
@@ -836,8 +842,8 @@
         },
         "Unread": {
           "description": "Total number of messages in the database",
-          "type": "integer",
-          "format": "int64"
+          "type": "number",
+          "format": "double"
         },
         "Version": {
           "description": "Current Mailpit version",
@@ -868,8 +874,8 @@
         },
         "Size": {
           "description": "Size in bytes",
-          "type": "integer",
-          "format": "int64"
+          "type": "number",
+          "format": "double"
         }
       },
       "x-go-package": "github.com/axllent/mailpit/internal/storage"
@@ -1176,8 +1182,8 @@
         },
         "Size": {
           "description": "Message size in bytes",
-          "type": "integer",
-          "format": "int64"
+          "type": "number",
+          "format": "double"
         },
         "Subject": {
           "description": "Message subject",
@@ -1268,8 +1274,8 @@
         },
         "Size": {
           "description": "Message size in bytes (total)",
-          "type": "integer",
-          "format": "int64"
+          "type": "number",
+          "format": "double"
         },
         "Snippet": {
           "description": "Message snippet includes up to 250 characters",
@@ -1310,8 +1316,8 @@
         },
         "messages_count": {
           "description": "Total number of messages matching current query",
-          "type": "integer",
-          "format": "int64",
+          "type": "number",
+          "format": "double",
           "x-go-name": "MessagesCount"
         },
         "start": {
@@ -1330,14 +1336,14 @@
         },
         "total": {
           "description": "Total number of messages in mailbox",
-          "type": "integer",
-          "format": "int64",
+          "type": "number",
+          "format": "double",
           "x-go-name": "Total"
         },
         "unread": {
           "description": "Total number of unread messages in mailbox",
-          "type": "integer",
-          "format": "int64",
+          "type": "number",
+          "format": "double",
           "x-go-name": "Unread"
         }
       },

--- a/testing/src/conf/openapi.json
+++ b/testing/src/conf/openapi.json
@@ -40,9 +40,9 @@
         "operationId": "AppInformation",
         "responses": {
           "200": {
-            "$ref": "#/responses/InfoResponse"
+            "$ref": "#/responses/AppInfoResponse"
           },
-          "default": {
+          "400": {
             "$ref": "#/responses/ErrorResponse"
           }
         }
@@ -62,7 +62,7 @@
           "message"
         ],
         "summary": "Get message summary",
-        "operationId": "Message",
+        "operationId": "GetMessageParams",
         "parameters": [
           {
             "type": "string",
@@ -79,15 +79,18 @@
               "$ref": "#/definitions/Message"
             }
           },
-          "default": {
+          "400": {
             "$ref": "#/responses/ErrorResponse"
+          },
+          "404": {
+            "$ref": "#/responses/NotFoundResponse"
           }
         }
       }
     },
     "/api/v1/message/{ID}/headers": {
       "get": {
-        "description": "Returns the message headers as an array.\n\nThe ID can be set to `latest` to return the latest message headers.",
+        "description": "Returns the message headers as an array. Note that header keys are returned alphabetically.\n\nThe ID can be set to `latest` to return the latest message headers.",
         "produces": [
           "application/json"
         ],
@@ -99,7 +102,7 @@
           "message"
         ],
         "summary": "Get message headers",
-        "operationId": "Headers",
+        "operationId": "GetHeadersParams",
         "parameters": [
           {
             "type": "string",
@@ -111,20 +114,23 @@
         ],
         "responses": {
           "200": {
-            "description": "MessageHeaders",
+            "description": "MessageHeadersResponse",
             "schema": {
-              "$ref": "#/definitions/MessageHeaders"
+              "$ref": "#/definitions/MessageHeadersResponse"
             }
           },
-          "default": {
+          "400": {
             "$ref": "#/responses/ErrorResponse"
+          },
+          "404": {
+            "$ref": "#/responses/NotFoundResponse"
           }
         }
       }
     },
     "/api/v1/message/{ID}/html-check": {
       "get": {
-        "description": "Returns the summary of the message HTML checker.",
+        "description": "Returns the summary of the message HTML checker.\n\nThe ID can be set to `latest` to return the latest message.",
         "produces": [
           "application/json"
         ],
@@ -136,7 +142,7 @@
           "Other"
         ],
         "summary": "HTML check",
-        "operationId": "HTMLCheck",
+        "operationId": "HTMLCheckParams",
         "parameters": [
           {
             "type": "string",
@@ -153,15 +159,18 @@
               "$ref": "#/definitions/HTMLCheckResponse"
             }
           },
-          "default": {
+          "400": {
             "$ref": "#/responses/ErrorResponse"
+          },
+          "404": {
+            "$ref": "#/responses/NotFoundResponse"
           }
         }
       }
     },
     "/api/v1/message/{ID}/link-check": {
       "get": {
-        "description": "Returns the summary of the message Link checker.",
+        "description": "Returns the summary of the message Link checker.\n\nThe ID can be set to `latest` to return the latest message.",
         "produces": [
           "application/json"
         ],
@@ -173,7 +182,7 @@
           "Other"
         ],
         "summary": "Link check",
-        "operationId": "LinkCheck",
+        "operationId": "LinkCheckParams",
         "parameters": [
           {
             "type": "string",
@@ -198,15 +207,18 @@
               "$ref": "#/definitions/LinkCheckResponse"
             }
           },
-          "default": {
+          "400": {
             "$ref": "#/responses/ErrorResponse"
+          },
+          "404": {
+            "$ref": "#/responses/NotFoundResponse"
           }
         }
       }
     },
     "/api/v1/message/{ID}/part/{PartID}": {
       "get": {
-        "description": "This will return the attachment part using the appropriate Content-Type.",
+        "description": "This will return the attachment part using the appropriate Content-Type.\n\nThe ID can be set to `latest` to reference the latest message.",
         "produces": [
           "application/*",
           "image/*",
@@ -220,11 +232,11 @@
           "message"
         ],
         "summary": "Get message attachment",
-        "operationId": "Attachment",
+        "operationId": "AttachmentParams",
         "parameters": [
           {
             "type": "string",
-            "description": "Message database ID",
+            "description": "Message database ID or \"latest\"",
             "name": "ID",
             "in": "path",
             "required": true
@@ -241,15 +253,18 @@
           "200": {
             "$ref": "#/responses/BinaryResponse"
           },
-          "default": {
+          "400": {
             "$ref": "#/responses/ErrorResponse"
+          },
+          "404": {
+            "$ref": "#/responses/NotFoundResponse"
           }
         }
       }
     },
     "/api/v1/message/{ID}/part/{PartID}/thumb": {
       "get": {
-        "description": "This will return a cropped 180x120 JPEG thumbnail of an image attachment.\nIf the image is smaller than 180x120 then the image is padded. If the attachment is not an image then a blank image is returned.",
+        "description": "This will return a cropped 180x120 JPEG thumbnail of an image attachment.\nIf the image is smaller than 180x120 then the image is padded. If the attachment is not an image then a blank image is returned.\n\nThe ID can be set to `latest` to return the latest message.",
         "produces": [
           "image/jpeg"
         ],
@@ -261,11 +276,11 @@
           "message"
         ],
         "summary": "Get an attachment image thumbnail",
-        "operationId": "Thumbnail",
+        "operationId": "ThumbnailParams",
         "parameters": [
           {
             "type": "string",
-            "description": "Database ID",
+            "description": "Message database ID or \"latest\"",
             "name": "ID",
             "in": "path",
             "required": true
@@ -282,7 +297,7 @@
           "200": {
             "$ref": "#/responses/BinaryResponse"
           },
-          "default": {
+          "400": {
             "$ref": "#/responses/ErrorResponse"
           }
         }
@@ -302,7 +317,7 @@
           "message"
         ],
         "summary": "Get message source",
-        "operationId": "Raw",
+        "operationId": "DownloadRawParams",
         "parameters": [
           {
             "type": "string",
@@ -316,15 +331,18 @@
           "200": {
             "$ref": "#/responses/TextResponse"
           },
-          "default": {
+          "400": {
             "$ref": "#/responses/ErrorResponse"
+          },
+          "404": {
+            "$ref": "#/responses/NotFoundResponse"
           }
         }
       }
     },
     "/api/v1/message/{ID}/release": {
       "post": {
-        "description": "Release a message via a pre-configured external SMTP server. This is only enabled if message relaying has been configured.",
+        "description": "Release a message via a pre-configured external SMTP server. This is only enabled if message relaying has been configured.\n\nThe ID can be set to `latest` to reference the latest message.",
         "consumes": [
           "application/json"
         ],
@@ -339,7 +357,7 @@
           "message"
         ],
         "summary": "Release message",
-        "operationId": "ReleaseMessage",
+        "operationId": "ReleaseMessageParams",
         "parameters": [
           {
             "type": "string",
@@ -352,7 +370,23 @@
             "name": "Body",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/releaseMessageRequestBody"
+              "type": "object",
+              "required": [
+                "To"
+              ],
+              "properties": {
+                "To": {
+                  "description": "Array of email addresses to relay the message to",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "example": [
+                    "user1@example.com",
+                    "user2@example.com"
+                  ]
+                }
+              }
             }
           }
         ],
@@ -360,15 +394,18 @@
           "200": {
             "$ref": "#/responses/OKResponse"
           },
-          "default": {
+          "400": {
             "$ref": "#/responses/ErrorResponse"
+          },
+          "404": {
+            "$ref": "#/responses/NotFoundResponse"
           }
         }
       }
     },
     "/api/v1/message/{ID}/sa-check": {
       "get": {
-        "description": "Returns the SpamAssassin summary (if enabled) of the message.",
+        "description": "Returns the SpamAssassin summary (if enabled) of the message.\n\nThe ID can be set to `latest` to return the latest message.",
         "produces": [
           "application/json"
         ],
@@ -380,7 +417,7 @@
           "Other"
         ],
         "summary": "SpamAssassin check",
-        "operationId": "SpamAssassinCheck",
+        "operationId": "SpamAssassinCheckParams",
         "parameters": [
           {
             "type": "string",
@@ -397,8 +434,11 @@
               "$ref": "#/definitions/SpamAssassinResponse"
             }
           },
-          "default": {
+          "400": {
             "$ref": "#/responses/ErrorResponse"
+          },
+          "404": {
+            "$ref": "#/responses/NotFoundResponse"
           }
         }
       }
@@ -417,19 +457,23 @@
           "messages"
         ],
         "summary": "List messages",
-        "operationId": "GetMessages",
+        "operationId": "GetMessagesParams",
         "parameters": [
           {
             "type": "integer",
+            "format": "int64",
             "default": 0,
+            "x-go-name": "Start",
             "description": "Pagination offset",
             "name": "start",
             "in": "query"
           },
           {
             "type": "integer",
+            "format": "int64",
             "default": 50,
-            "description": "Limit results",
+            "x-go-name": "Limit",
+            "description": "Limit number of results",
             "name": "limit",
             "in": "query"
           }
@@ -438,7 +482,7 @@
           "200": {
             "$ref": "#/responses/MessagesSummaryResponse"
           },
-          "default": {
+          "400": {
             "$ref": "#/responses/ErrorResponse"
           }
         }
@@ -459,13 +503,32 @@
           "messages"
         ],
         "summary": "Set read status",
-        "operationId": "SetReadStatus",
+        "operationId": "SetReadStatusParams",
         "parameters": [
           {
             "name": "Body",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/setReadStatusRequestBody"
+              "type": "object",
+              "properties": {
+                "IDs": {
+                  "description": "Array of message database IDs",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "example": [
+                    "4oRBnPtCXgAqZniRhzLNmS",
+                    "hXayS6wnCgNnt6aFTvmOF6"
+                  ]
+                },
+                "Read": {
+                  "description": "Read status",
+                  "type": "boolean",
+                  "default": false,
+                  "example": true
+                }
+              }
             }
           }
         ],
@@ -473,7 +536,7 @@
           "200": {
             "$ref": "#/responses/OKResponse"
           },
-          "default": {
+          "400": {
             "$ref": "#/responses/ErrorResponse"
           }
         }
@@ -494,13 +557,27 @@
           "messages"
         ],
         "summary": "Delete messages",
-        "operationId": "DeleteMessages",
+        "operationId": "DeleteMessagesParams",
         "parameters": [
           {
+            "description": "Delete request",
             "name": "Body",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/DeleteRequest"
+              "type": "object",
+              "properties": {
+                "IDs": {
+                  "description": "Array of message database IDs",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "example": [
+                    "4oRBnPtCXgAqZniRhzLNmS",
+                    "hXayS6wnCgNnt6aFTvmOF6"
+                  ]
+                }
+              }
             }
           }
         ],
@@ -508,7 +585,7 @@
           "200": {
             "$ref": "#/responses/OKResponse"
           },
-          "default": {
+          "400": {
             "$ref": "#/responses/ErrorResponse"
           }
         }
@@ -528,32 +605,34 @@
           "messages"
         ],
         "summary": "Search messages",
-        "operationId": "MessagesSummary",
+        "operationId": "SearchParams",
         "parameters": [
           {
             "type": "string",
+            "x-go-name": "Query",
             "description": "Search query",
             "name": "query",
             "in": "query",
             "required": true
           },
           {
-            "type": "integer",
-            "default": 0,
+            "type": "string",
+            "x-go-name": "Start",
             "description": "Pagination offset",
             "name": "start",
             "in": "query"
           },
           {
-            "type": "integer",
-            "default": 50,
+            "type": "string",
+            "x-go-name": "Limit",
             "description": "Limit results",
             "name": "limit",
             "in": "query"
           },
           {
             "type": "string",
-            "description": "[Timezone identifier](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) used specifically for `before:` \u0026 `after:` searches (eg: \"Pacific/Auckland\").",
+            "x-go-name": "TZ",
+            "description": "[Timezone identifier](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) used only for `before:` \u0026 `after:` searches (eg: \"Pacific/Auckland\").",
             "name": "tz",
             "in": "query"
           }
@@ -562,7 +641,7 @@
           "200": {
             "$ref": "#/responses/MessagesSummaryResponse"
           },
-          "default": {
+          "400": {
             "$ref": "#/responses/ErrorResponse"
           }
         }
@@ -580,10 +659,11 @@
           "messages"
         ],
         "summary": "Delete messages by search",
-        "operationId": "DeleteSearch",
+        "operationId": "DeleteSearchParams",
         "parameters": [
           {
             "type": "string",
+            "x-go-name": "Query",
             "description": "Search query",
             "name": "query",
             "in": "query",
@@ -591,7 +671,8 @@
           },
           {
             "type": "string",
-            "description": "[Timezone identifier](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) used specifically for `before:` \u0026 `after:` searches (eg: \"Pacific/Auckland\").",
+            "x-go-name": "TZ",
+            "description": "[Timezone identifier](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) used only for `before:` \u0026 `after:` searches (eg: \"Pacific/Auckland\").",
             "name": "tz",
             "in": "query"
           }
@@ -600,7 +681,7 @@
           "200": {
             "$ref": "#/responses/OKResponse"
           },
-          "default": {
+          "400": {
             "$ref": "#/responses/ErrorResponse"
           }
         }
@@ -623,7 +704,7 @@
           "message"
         ],
         "summary": "Send a message",
-        "operationId": "SendMessage",
+        "operationId": "SendMessageParams",
         "parameters": [
           {
             "name": "Body",
@@ -637,7 +718,7 @@
           "200": {
             "$ref": "#/responses/sendMessageResponse"
           },
-          "default": {
+          "400": {
             "$ref": "#/responses/jsonErrorResponse"
           }
         }
@@ -662,7 +743,7 @@
           "200": {
             "$ref": "#/responses/ArrayResponse"
           },
-          "default": {
+          "400": {
             "$ref": "#/responses/ErrorResponse"
           }
         }
@@ -683,13 +764,41 @@
           "tags"
         ],
         "summary": "Set message tags",
-        "operationId": "SetTags",
+        "operationId": "SetTagsParams",
         "parameters": [
           {
             "name": "Body",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/setTagsRequestBody"
+              "type": "object",
+              "required": [
+                "Tags",
+                "IDs"
+              ],
+              "properties": {
+                "IDs": {
+                  "description": "Array of message database IDs",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "example": [
+                    "4oRBnPtCXgAqZniRhzLNmS",
+                    "hXayS6wnCgNnt6aFTvmOF6"
+                  ]
+                },
+                "Tags": {
+                  "description": "Array of tag names to set",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "example": [
+                    "Tag 1",
+                    "Tag 2"
+                  ]
+                }
+              }
             }
           }
         ],
@@ -697,15 +806,15 @@
           "200": {
             "$ref": "#/responses/OKResponse"
           },
-          "default": {
+          "400": {
             "$ref": "#/responses/ErrorResponse"
           }
         }
       }
     },
-    "/api/v1/tags/{tag}": {
+    "/api/v1/tags/{Tag}": {
       "put": {
-        "description": "Renames a tag.",
+        "description": "Renames an existing tag.",
         "produces": [
           "text/plain"
         ],
@@ -717,34 +826,44 @@
           "tags"
         ],
         "summary": "Rename a tag",
-        "operationId": "RenameTag",
+        "operationId": "RenameTagParams",
         "parameters": [
+          {
+            "type": "string",
+            "description": "The url-encoded tag name to rename",
+            "name": "Tag",
+            "in": "path",
+            "required": true
+          },
           {
             "name": "Body",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/renameTagRequestBody"
+              "type": "object",
+              "required": [
+                "Name"
+              ],
+              "properties": {
+                "Name": {
+                  "description": "New name",
+                  "type": "string",
+                  "example": "New name"
+                }
+              }
             }
-          },
-          {
-            "type": "string",
-            "description": "The url-encoded tag name to rename",
-            "name": "tag",
-            "in": "path",
-            "required": true
           }
         ],
         "responses": {
           "200": {
             "$ref": "#/responses/OKResponse"
           },
-          "default": {
+          "400": {
             "$ref": "#/responses/ErrorResponse"
           }
         }
       },
       "delete": {
-        "description": "Deletes a tag. This will not delete any messages with this tag.",
+        "description": "Deletes a tag. This will not delete any messages with the tag, but will remove the tag from any messages containing the tag.",
         "produces": [
           "text/plain"
         ],
@@ -756,12 +875,12 @@
           "tags"
         ],
         "summary": "Delete a tag",
-        "operationId": "DeleteTag",
+        "operationId": "DeleteTagParams",
         "parameters": [
           {
             "type": "string",
             "description": "The url-encoded tag name to delete",
-            "name": "tag",
+            "name": "Tag",
             "in": "path",
             "required": true
           }
@@ -770,7 +889,7 @@
           "200": {
             "$ref": "#/responses/OKResponse"
           },
-          "default": {
+          "400": {
             "$ref": "#/responses/ErrorResponse"
           }
         }
@@ -795,7 +914,7 @@
           "200": {
             "$ref": "#/responses/WebUIConfigurationResponse"
           },
-          "default": {
+          "400": {
             "$ref": "#/responses/ErrorResponse"
           }
         }
@@ -815,11 +934,11 @@
           "testing"
         ],
         "summary": "Render message HTML part",
-        "operationId": "GetMessageHTML",
+        "operationId": "GetMessageHTMLParams",
         "parameters": [
           {
             "type": "string",
-            "description": "Database ID or latest",
+            "description": "Message database ID or \"latest\"",
             "name": "ID",
             "in": "path",
             "required": true
@@ -829,8 +948,11 @@
           "200": {
             "$ref": "#/responses/HTMLResponse"
           },
-          "default": {
+          "400": {
             "$ref": "#/responses/ErrorResponse"
+          },
+          "404": {
+            "$ref": "#/responses/NotFoundResponse"
           }
         }
       }
@@ -849,11 +971,11 @@
           "testing"
         ],
         "summary": "Render message text part",
-        "operationId": "GetMessageText",
+        "operationId": "GetMessageTextParams",
         "parameters": [
           {
             "type": "string",
-            "description": "Database ID or latest",
+            "description": "Message database ID or \"latest\"",
             "name": "ID",
             "in": "path",
             "required": true
@@ -863,8 +985,11 @@
           "200": {
             "$ref": "#/responses/TextResponse"
           },
-          "default": {
+          "400": {
             "$ref": "#/responses/ErrorResponse"
+          },
+          "404": {
+            "$ref": "#/responses/NotFoundResponse"
           }
         }
       }
@@ -995,25 +1120,6 @@
         }
       },
       "x-go-package": "github.com/axllent/mailpit/internal/storage"
-    },
-    "DeleteRequest": {
-      "description": "Delete request",
-      "type": "object",
-      "properties": {
-        "IDs": {
-          "description": "Array of message database IDs",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "example": [
-            "5dec4247-812e-4b77-9101-e25ad406e9ea",
-            "8ac66bbc-2d9a-4c41-ad99-00aa75fa674e"
-          ]
-        }
-      },
-      "x-go-name": "deleteMessagesRequestBody",
-      "x-go-package": "github.com/axllent/mailpit/server/apiv1"
     },
     "HTMLCheckResponse": {
       "description": "Response represents the HTML check response struct",
@@ -1337,7 +1443,7 @@
       },
       "x-go-package": "github.com/axllent/mailpit/internal/storage"
     },
-    "MessageHeaders": {
+    "MessageHeadersResponse": {
       "description": "Message headers",
       "type": "object",
       "additionalProperties": {
@@ -1503,7 +1609,7 @@
         "ID": {
           "description": "Database ID",
           "type": "string",
-          "example": "iAfZVVe2UQFNSG5BAjgYwa"
+          "example": "iAfZVVe2UQfNSG5BAjgYwa"
         }
       },
       "x-go-package": "github.com/axllent/mailpit/server/apiv1"
@@ -1528,12 +1634,22 @@
               "Content": {
                 "description": "Base64-encoded string of the file content",
                 "type": "string",
-                "example": "VGhpcyBpcyBhIHBsYWluIHRleHQgYXR0YWNobWVudA=="
+                "example": "iVBORw0KGgoAAAANSUhEUgAAAEEAAAA8CAMAAAAOlSdoAAAACXBIWXMAAAHrAAAB6wGM2bZBAAAAS1BMVEVHcEwRfnUkZ2gAt4UsSF8At4UtSV4At4YsSV4At4YsSV8At4YsSV4At4YsSV4sSV4At4YsSV4At4YtSV4At4YsSV4At4YtSV8At4YsUWYNAAAAGHRSTlMAAwoXGiktRE5dbnd7kpOlr7zJ0d3h8PD8PCSRAAACWUlEQVR42pXT4ZaqIBSG4W9rhqQYocG+/ys9Y0Z0Br+x3j8zaxUPewFh65K+7yrIMeIY4MT3wPfEJCidKXEMnLaVkxDiELiMz4WEOAZSFghxBIypCOlKiAMgXfIqTnBgSm8CIQ6BImxEUxEckClVQiHGj4Ba4AQHikAIClwTE9KtIghAhUJwoLkmLnCiAHJLRKgIMsEtVUKbBUIwoAg2C4QgQBE6l4VCnApBgSKYLLApCnCa0+96AEMW2BQcmC+Pr3nfp7o5Exy49gIADcIqUELGfeA+bp93LmAJp8QJoEcN3C7NY3sbVANixMyI0nku20/n5/ZRf3KI2k6JEDWQtxcbdGuAqu3TAXG+/799Oyyas1B1MnMiA+XyxHp9q0PUKGPiRAau1fZbLRZV09wZcT8/gHk8QQAxXn8VgaDqcUmU6O/r28nbVwXAqca2mRNtPAF5+zoP2MeN9Fy4NgC6RfcbgE7XITBRYTtOE3U3C2DVff7pk+PkUxgAbvtnPXJaD6DxulMLwOhPS/M3MQkgg1ZFrIXnmfaZoOfpKiFgzeZD/WuKqQEGrfJYkyWf6vlG3xUgTuscnkNkQsb599q124kdpMUjCa/XARHs1gZymVtGt3wLkiFv8rUgTxitYCex5EVGec0Y9VmoDTFBSQte2TfXGXlf7hbdaUM9Sk7fisEN9qfBBTK+FZcvM9fQSdkl2vj4W2oX/bRogO3XasiNH7R0eW7fgRM834ImTg+Lg6BEnx4vz81rhr+MYPBBQg1v8GndEOrthxaCTxNAOut8WKLGZQl+MPz88Q9tAO/hVuSeqQAAAABJRU5ErkJggg=="
+              },
+              "ContentID": {
+                "description": "Optional Content-ID (`cid`) for attachment.\nIf this field is set then the file is attached inline.",
+                "type": "string",
+                "example": "mailpit-logo"
+              },
+              "ContentType": {
+                "description": "Optional Content Type for the the attachment.\nIf this field is not set (or empty) then the content type is automatically detected.",
+                "type": "string",
+                "example": "image/png"
               },
               "Filename": {
                 "description": "Filename",
                 "type": "string",
-                "example": "AttachedFile.txt"
+                "example": "mailpit.png"
               }
             }
           }
@@ -1592,7 +1708,7 @@
         "HTML": {
           "description": "Message body (HTML)",
           "type": "string",
-          "example": "\u003cp style=\"font-family: arial\"\u003eMailpit is \u003cb\u003eawesome\u003c/b\u003e!\u003c/p\u003e"
+          "example": "\u003cdiv style=\"text-align:center\"\u003e\u003cp style=\"font-family: arial; font-size: 24px;\"\u003eMailpit is \u003cb\u003eawesome\u003c/b\u003e!\u003c/p\u003e\u003cp\u003e\u003cimg src=\"cid:mailpit-logo\" /\u003e\u003c/p\u003e\u003c/div\u003e"
         },
         "Headers": {
           "description": "Optional headers in {\"key\":\"value\"} format",
@@ -1645,7 +1761,7 @@
         "Text": {
           "description": "Message body (text)",
           "type": "string",
-          "example": "This is the text body"
+          "example": "Mailpit is awesome!"
         },
         "To": {
           "description": "\"To\" recipients",
@@ -1745,102 +1861,15 @@
       },
       "x-go-name": "webUIConfiguration",
       "x-go-package": "github.com/axllent/mailpit/server/apiv1"
-    },
-    "releaseMessageRequestBody": {
-      "description": "Release request",
-      "type": "object",
-      "required": [
-        "To"
-      ],
-      "properties": {
-        "To": {
-          "description": "Array of email addresses to relay the message to",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "example": [
-            "user1@example.com",
-            "user2@example.com"
-          ]
-        }
-      },
-      "x-go-package": "github.com/axllent/mailpit/server/apiv1"
-    },
-    "renameTagRequestBody": {
-      "description": "Rename tag request",
-      "type": "object",
-      "required": [
-        "Name"
-      ],
-      "properties": {
-        "Name": {
-          "description": "New name",
-          "type": "string",
-          "example": "New name"
-        }
-      },
-      "x-go-package": "github.com/axllent/mailpit/server/apiv1"
-    },
-    "setReadStatusRequestBody": {
-      "description": "Set read status request",
-      "type": "object",
-      "properties": {
-        "IDs": {
-          "description": "Array of message database IDs",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "example": [
-            "5dec4247-812e-4b77-9101-e25ad406e9ea",
-            "8ac66bbc-2d9a-4c41-ad99-00aa75fa674e"
-          ]
-        },
-        "Read": {
-          "description": "Read status",
-          "type": "boolean",
-          "default": false,
-          "example": true
-        }
-      },
-      "x-go-package": "github.com/axllent/mailpit/server/apiv1"
-    },
-    "setTagsRequestBody": {
-      "description": "Set tags request",
-      "type": "object",
-      "required": [
-        "Tags",
-        "IDs"
-      ],
-      "properties": {
-        "IDs": {
-          "description": "Array of message database IDs",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "example": [
-            "5dec4247-812e-4b77-9101-e25ad406e9ea",
-            "8ac66bbc-2d9a-4c41-ad99-00aa75fa674e"
-          ]
-        },
-        "Tags": {
-          "description": "Array of tag names to set",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "example": [
-            "Tag 1",
-            "Tag 2"
-          ]
-        }
-      },
-      "x-go-package": "github.com/axllent/mailpit/server/apiv1"
     }
   },
   "responses": {
+    "AppInfoResponse": {
+      "description": "Application information",
+      "schema": {
+        "$ref": "#/definitions/AppInformation"
+      }
+    },
     "ArrayResponse": {
       "description": "Plain JSON array response",
       "schema": {
@@ -1851,13 +1880,13 @@
       }
     },
     "BinaryResponse": {
-      "description": "Binary data response inherits the attachment's content type.",
+      "description": "Binary data response which inherits the attachment's content type.",
       "schema": {
         "type": "string"
       }
     },
     "ErrorResponse": {
-      "description": "HTTP error response will return with a \u003e= 400 response code",
+      "description": "Server error will return with a 400 status code\nwith the error message in the body",
       "schema": {
         "type": "string"
       }
@@ -1868,16 +1897,16 @@
         "type": "string"
       }
     },
-    "InfoResponse": {
-      "description": "Application information",
-      "schema": {
-        "$ref": "#/definitions/AppInformation"
-      }
-    },
     "MessagesSummaryResponse": {
-      "description": "Message summary",
+      "description": "Summary of messages",
       "schema": {
         "$ref": "#/definitions/MessagesSummary"
+      }
+    },
+    "NotFoundResponse": {
+      "description": "Not found error will return a 404 status code",
+      "schema": {
+        "type": "string"
       }
     },
     "OKResponse": {
@@ -1893,7 +1922,7 @@
       }
     },
     "WebUIConfigurationResponse": {
-      "description": "Web UI configuration",
+      "description": "Web UI configuration response",
       "schema": {
         "$ref": "#/definitions/WebUIConfiguration"
       }

--- a/testing/src/main/java/io/quarkiverse/mailpit/test/Mailbox.java
+++ b/testing/src/main/java/io/quarkiverse/mailpit/test/Mailbox.java
@@ -14,11 +14,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import io.quarkiverse.mailpit.test.invoker.ApiClient;
 import io.quarkiverse.mailpit.test.invoker.ApiException;
-import io.quarkiverse.mailpit.test.model.AppInformation;
-import io.quarkiverse.mailpit.test.model.DeleteRequest;
-import io.quarkiverse.mailpit.test.model.Message;
-import io.quarkiverse.mailpit.test.model.MessageSummary;
-import io.quarkiverse.mailpit.test.model.MessagesSummary;
+import io.quarkiverse.mailpit.test.model.*;
 import io.quarkiverse.mailpit.test.rest.ApplicationApi;
 import io.quarkiverse.mailpit.test.rest.MessageApi;
 import io.quarkiverse.mailpit.test.rest.MessagesApi;
@@ -39,10 +35,10 @@ public class Mailbox {
      */
     public void delete(String ID) {
         final MessagesApi messagesApi = getMessagesApi();
-        final DeleteRequest request = new DeleteRequest();
+        final DeleteMessagesParamsRequest request = new DeleteMessagesParamsRequest();
         request.addIdsItem(ID);
         try {
-            messagesApi.deleteMessages(request);
+            messagesApi.deleteMessagesParams(request);
         } catch (ApiException e) {
             rethrow(e);
         }
@@ -54,9 +50,9 @@ public class Mailbox {
      */
     public void clear() {
         final MessagesApi messagesApi = getMessagesApi();
-        final DeleteRequest request = new DeleteRequest();
+        final DeleteMessagesParamsRequest request = new DeleteMessagesParamsRequest();
         try {
-            messagesApi.deleteMessages(request);
+            messagesApi.deleteMessagesParams(request);
         } catch (ApiException e) {
             rethrow(e);
         }
@@ -88,13 +84,21 @@ public class Mailbox {
         final MessagesApi messagesApi = getMessagesApi();
         final MessageApi messageApi = getMessageApi();
         try {
+            String startStr = null;
+            if (start != null) {
+                startStr = start.toString();
+            }
+            String limitStr = null;
+            if (limit != null) {
+                limitStr = limit.toString();
+            }
             String timezoneID = null;
             if (timeZone != null) {
                 timezoneID = timeZone.getID();
             }
-            final MessagesSummary messages = messagesApi.messagesSummary(query, start, limit, timezoneID);
+            final MessagesSummary messages = messagesApi.searchParams(query, startStr, limitStr, timezoneID);
             for (MessageSummary summary : Objects.requireNonNull(messages.getMessages())) {
-                Message message = messageApi.message(summary.getID());
+                Message message = messageApi.getMessageParams(summary.getID());
                 results.add(message);
             }
         } catch (ApiException e) {

--- a/testing/src/main/java/io/quarkiverse/mailpit/test/Mailbox.java
+++ b/testing/src/main/java/io/quarkiverse/mailpit/test/Mailbox.java
@@ -2,10 +2,7 @@ package io.quarkiverse.mailpit.test;
 
 import java.net.http.HttpClient;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 
@@ -74,11 +71,28 @@ public class Mailbox {
      * @return List<Message>
      */
     public List<Message> find(String query, Integer start, Integer limit) {
+        return find(query, start, limit, null);
+    }
+
+    /**
+     * Search messages. Returns the latest messages matching a search.
+     *
+     * @param query Search query (required)
+     * @param start Pagination offset (optional, default to 0)
+     * @param limit Limit results (optional, default to 50)
+     * @param timeZone Specify a timezone for before: and after: queries (optional, default null)
+     * @return List<Message>
+     */
+    public List<Message> find(String query, Integer start, Integer limit, TimeZone timeZone) {
         final List<Message> results = new ArrayList<>();
         final MessagesApi messagesApi = getMessagesApi();
         final MessageApi messageApi = getMessageApi();
         try {
-            final MessagesSummary messages = messagesApi.messagesSummary(query, start, limit);
+            String timezoneID = null;
+            if (timeZone != null) {
+                timezoneID = timeZone.getID();
+            }
+            final MessagesSummary messages = messagesApi.messagesSummary(query, start, limit, timezoneID);
             for (MessageSummary summary : Objects.requireNonNull(messages.getMessages())) {
                 Message message = messageApi.message(summary.getID());
                 results.add(message);

--- a/testing/src/main/java/io/quarkiverse/mailpit/test/Mailbox.java
+++ b/testing/src/main/java/io/quarkiverse/mailpit/test/Mailbox.java
@@ -45,7 +45,7 @@ public class Mailbox {
         final DeleteRequest request = new DeleteRequest();
         request.addIdsItem(ID);
         try {
-            messagesApi.delete(request);
+            messagesApi.deleteMessages(request);
         } catch (ApiException e) {
             rethrow(e);
         }
@@ -59,7 +59,7 @@ public class Mailbox {
         final MessagesApi messagesApi = getMessagesApi();
         final DeleteRequest request = new DeleteRequest();
         try {
-            messagesApi.delete(request);
+            messagesApi.deleteMessages(request);
         } catch (ApiException e) {
             rethrow(e);
         }


### PR DESCRIPTION
This updates the OpenAPI spec to version v1.21.8.

WARNING: Anyone using the MessagesApi or MessageApi directly will have breaking changes.
This is a major change in [semver](https://semver.org). 

Summary of breaking changes I am aware of from code that uses them but there are probably many more if users use the MessagesApi or MessageAPI directly.

```
messagesApi.delete() has changed to messagesApi.deleteMessagesParams()
DeleteRequest has been renamed to DeleteMessagesParamsRequest
messagesApi.messagesSummary() has changed to messagesApi.searchParams()
messageApi.message() has changed to getMessageParams()
```

Sadly I couldn't update all the way to v1.22.* (which adds the chaos testing APIs) because there seem to be issues with the OpenAPI generator which I didn't dig into but did file an [issue](https://github.com/OpenAPITools/openapi-generator/issues/20607). 

