### PR TITLE
Add mailbox.setChaos() and mailbox.disableChaos() and integration tests.

### DIFF
--- a/integration-tests/src/test/java/io/quarkiverse/mailpit/it/MailpitResourceTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/mailpit/it/MailpitResourceTest.java
@@ -12,6 +12,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import io.quarkiverse.mailpit.test.ChaosConfig;
 import io.quarkiverse.mailpit.test.InjectMailbox;
 import io.quarkiverse.mailpit.test.Mailbox;
 import io.quarkiverse.mailpit.test.WithMailbox;
@@ -31,6 +32,9 @@ public class MailpitResourceTest {
     public void afterEach() {
         // clear the mailbox after each test run if you prefer
         mailbox.clear();
+
+        // disable chaos testing after each test run if you prefer or disable in a finally block
+        mailbox.disableChaos();
     }
 
     @Test
@@ -112,6 +116,60 @@ public class MailpitResourceTest {
         if (StringUtils.isNotBlank((stack))) {
             // native mode does not have the stack trace
             assertThat(stack, containsStringIgnoringCase("sender address is not present"));
+        }
+    }
+
+    @Test
+    public void ensureChaosTestingSenderReturnsError() {
+        try {
+            mailbox.setChaos(
+                    ChaosConfig.builder()
+                            .authentication(451, 0)
+                            .sender(451, 100)
+                            .recipient(451, 0)
+                            .build());
+
+            Response response = given()
+                    .when().get("/mailpit/alert")
+                    .then()
+                    .statusCode(500)
+                    .and()
+                    .body("$", notNullValue())
+                    .extract().response();
+
+            JsonPath json = new JsonPath(response.asString());
+            String stack = json.get("stack").toString();
+            if (StringUtils.isNotBlank((stack))) {
+                // native mode does not have the stack trace
+                assertThat(stack, containsStringIgnoringCase("sender address not accepted"));
+            }
+        } finally {
+            mailbox.disableChaos();
+        }
+    }
+
+    @Test
+    public void ensureChaosTestingRecipientReturnsError() {
+        mailbox.setChaos(
+                ChaosConfig.builder()
+                        .authentication(451, 0)
+                        .sender(451, 0)
+                        .recipient(451, 100)
+                        .build());
+
+        Response response = given()
+                .when().get("/mailpit/alert")
+                .then()
+                .statusCode(500)
+                .and()
+                .body("$", notNullValue())
+                .extract().response();
+
+        JsonPath json = new JsonPath(response.asString());
+        String stack = json.get("stack").toString();
+        if (StringUtils.isNotBlank((stack))) {
+            // native mode does not have the stack trace
+            assertThat(stack, containsStringIgnoringCase("recipient address not accepted"));
         }
     }
 }

--- a/integration-tests/src/test/resources/application.properties
+++ b/integration-tests/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.mailpit.enable-chaos=true

--- a/testing/src/main/java/io/quarkiverse/mailpit/test/ChaosConfig.java
+++ b/testing/src/main/java/io/quarkiverse/mailpit/test/ChaosConfig.java
@@ -1,0 +1,92 @@
+package io.quarkiverse.mailpit.test;
+
+import io.quarkiverse.mailpit.test.model.Trigger;
+import io.quarkiverse.mailpit.test.model.Triggers;
+
+public class ChaosConfig {
+    private final Trigger authentication;
+    private final Trigger recipient;
+    private final Trigger sender;
+
+    private ChaosConfig(Builder builder) {
+        this.authentication = builder.authentication;
+        this.recipient = builder.recipient;
+        this.sender = builder.sender;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Trigger authentication;
+        private Trigger recipient;
+        private Trigger sender;
+
+        public Builder authentication(int errorCode, int probability) {
+            this.authentication = getNewTrigger(errorCode, probability);
+            return this;
+        }
+
+        public Builder recipient(int errorCode, int probability) {
+            this.recipient = getNewTrigger(errorCode, probability);
+            return this;
+        }
+
+        public Builder sender(int errorCode, int probability) {
+            this.sender = getNewTrigger(errorCode, probability);
+            return this;
+        }
+
+        private Trigger getNewTrigger(int errorCode, int probability) {
+            assertErrorCode(errorCode);
+            assertProbability(probability);
+
+            Trigger trigger = new Trigger();
+            trigger.setErrorCode((long) errorCode);
+            trigger.setProbability((long) probability);
+
+            return trigger;
+        }
+
+        private static void assertProbability(int probability) {
+            if (probability < 0 || probability > 100) {
+                throw new IllegalArgumentException("Probability must be between 0 and 100.");
+            }
+        }
+
+        private static void assertErrorCode(int errorCode) {
+            if (errorCode < 400 || errorCode > 599) {
+                throw new IllegalArgumentException("ErrorCode must be a valid SMTP error code (400-599).");
+            }
+        }
+
+        public ChaosConfig build() {
+            // TODO: could make it less verbose and set up defaults as 0 probability
+            if (authentication == null || recipient == null || sender == null) {
+                throw new IllegalStateException("All fields (Authentication, Recipient, Sender) must be set.");
+            }
+            return new ChaosConfig(this);
+        }
+    }
+
+    public Triggers getTriggers() {
+        Triggers triggers = new Triggers();
+        triggers.setAuthentication(authentication);
+        triggers.setRecipient(recipient);
+        triggers.setSender(sender);
+
+        //TODO: We should probably not use Triggers and make our own object so that we can protect ourselves from swagger API changes
+
+        return triggers;
+    }
+
+    @Override
+    public String toString() {
+        return "ChaosConfig{" +
+                "authentication=" + authentication +
+                ", recipient=" + recipient +
+                ", sender=" + sender +
+                '}';
+    }
+}

--- a/testing/src/main/java/io/quarkiverse/mailpit/test/Mailbox.java
+++ b/testing/src/main/java/io/quarkiverse/mailpit/test/Mailbox.java
@@ -18,6 +18,7 @@ import io.quarkiverse.mailpit.test.model.*;
 import io.quarkiverse.mailpit.test.rest.ApplicationApi;
 import io.quarkiverse.mailpit.test.rest.MessageApi;
 import io.quarkiverse.mailpit.test.rest.MessagesApi;
+import io.quarkiverse.mailpit.test.rest.TestingApi;
 
 /**
  * Injected MailContext wrapping the API to Mailpit for unit testing.
@@ -27,6 +28,7 @@ public class Mailbox {
     private ApplicationApi applicationApi;
     private MessagesApi messagesApi;
     private MessageApi messageApi;
+    private TestingApi testingApi;
 
     /**
      * Delete a single message.
@@ -123,6 +125,40 @@ public class Mailbox {
     }
 
     /**
+     * Set chaos testing.
+     *
+     */
+    public void setChaos(ChaosConfig chaosConfig) {
+        final TestingApi testingApi = getTestingApi();
+
+        try {
+            testingApi.setChaosParams(chaosConfig.getTriggers());
+        } catch (ApiException e) {
+            rethrow(e);
+        }
+    }
+
+    /**
+     * Disable chaos testing.
+     *
+     */
+    public void disableChaos() {
+        final TestingApi testingApi = getTestingApi();
+
+        try {
+            ChaosConfig chaosConfig = ChaosConfig.builder()
+                    .authentication(451, 0)
+                    .sender(451, 0)
+                    .recipient(451, 0)
+                    .build();
+
+            testingApi.setChaosParams(chaosConfig.getTriggers());
+        } catch (ApiException e) {
+            rethrow(e);
+        }
+    }
+
+    /**
      * Get application information
      * Returns basic runtime information, message totals and latest release version.
      *
@@ -150,6 +186,13 @@ public class Mailbox {
             this.applicationApi = new ApplicationApi(this.getApiClient());
         }
         return this.applicationApi;
+    }
+
+    public TestingApi getTestingApi() {
+        if (this.testingApi == null) {
+            this.testingApi = new TestingApi(this.getApiClient());
+        }
+        return this.testingApi;
     }
 
     public MessagesApi getMessagesApi() {


### PR DESCRIPTION
Added the needed methods to mailbox and also added integration tests.

Please review the TODOs in the ChaosConfig class. 

We can make the builder more verbose by having default triggers with 0 probability or force users to supply all the triggers.

Also I think we should make our own ChaosTriggers class to hide the API objects from users... Let me know if you think this is overkill. 

I didn't test authentication chaos because mailpit [needs to be set up with authentication](https://mailpit.axllent.org/docs/integration/chaos/) for that...
```
Authentication - triggers on authentication (authentication must be configured in Mailpit, else this is ignored)
```

After this is merged can also update the docs PR