### PR TITLE
Update openapi.json to fix generation issue.

### DIFF
--- a/testing/src/conf/openapi.json
+++ b/testing/src/conf/openapi.json
@@ -69,7 +69,7 @@
             "name": "Body",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/Triggers"
+              "$ref": "#/definitions/ChaosTriggers"
             }
           }
         ],
@@ -1188,6 +1188,10 @@
       },
       "x-go-package": "github.com/axllent/mailpit/internal/storage"
     },
+    "ChaosTriggers": {
+      "description": "ChaosTriggers are the Chaos triggers",
+      "$ref": "#/definitions/Triggers"
+    },
     "HTMLCheckResponse": {
       "description": "Response represents the HTML check response struct",
       "type": "object",
@@ -1919,7 +1923,8 @@
         "Sender": {
           "$ref": "#/definitions/Trigger"
         }
-      }
+      },
+      "x-go-package": "github.com/axllent/mailpit/internal/smtpd/chaos"
     },
     "WebUIConfiguration": {
       "description": "Response includes global web UI settings",
@@ -2001,7 +2006,7 @@
     "ChaosResponse": {
       "description": "Response for the Chaos triggers configuration",
       "schema": {
-        "$ref": "#/definitions/Triggers"
+        "$ref": "#/definitions/ChaosTriggers"
       }
     },
     "ErrorResponse": {


### PR DESCRIPTION
Used 
https://raw.githubusercontent.com/axllent/mailpit/refs/heads/develop/server/ui/api/v1/swagger.json
from
https://github.com/axllent/mailpit/issues/442#issuecomment-2658174309

What appears to have changed is that now for the response when querying about the Chaos Trigger state is a different object.

Seems to work fine - no more generation issue.