### PR TITLE
Switch to using DevServicesConfig

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/mailpit/deployment/MailpitProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/mailpit/deployment/MailpitProcessor.java
@@ -20,14 +20,14 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.console.ConsoleInstalledBuildItem;
 import io.quarkus.deployment.console.StartupLogCompressor;
-import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
+import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.deployment.logging.LoggingSetupBuildItem;
 import io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem;
 
 /**
  * Starts a Mailpit server as dev service if needed.
  */
-@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
+@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = DevServicesConfig.Enabled.class)
 public class MailpitProcessor {
 
     private static final Logger log = Logger.getLogger(MailpitProcessor.class);
@@ -59,7 +59,7 @@ public class MailpitProcessor {
             MailpitConfig mailpitConfig,
             Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
             LoggingSetupBuildItem loggingSetupBuildItem,
-            GlobalDevServicesConfig devServicesConfig,
+            DevServicesConfig devServicesConfig,
             List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
             BuildProducer<MailpitDevServicesConfigBuildItem> mailpitBuildItemBuildProducer,
             CombinedIndexBuildItem combinedIndexBuildItem,
@@ -126,7 +126,7 @@ public class MailpitProcessor {
     }
 
     private DevServicesResultBuildItem.RunningDevService startMailpit(DockerStatusBuildItem dockerStatusBuildItem,
-            MailpitConfig mailpitConfig, GlobalDevServicesConfig devServicesConfig, boolean useSharedNetwork,
+            MailpitConfig mailpitConfig, DevServicesConfig devServicesConfig, boolean useSharedNetwork,
             IndexView index, String path) {
         if (!mailpitConfig.enabled()) {
             // explicitly disabled
@@ -140,7 +140,7 @@ public class MailpitProcessor {
         }
 
         final MailpitContainer mailpit = new MailpitContainer(mailpitConfig, useSharedNetwork, index, path);
-        devServicesConfig.timeout.ifPresent(mailpit::withStartupTimeout);
+        devServicesConfig.timeout().ifPresent(mailpit::withStartupTimeout);
         mailpit.start();
 
         return new DevServicesResultBuildItem.RunningDevService(FEATURE,

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.15.4</quarkus.version>
+    <quarkus.version>3.20.0</quarkus.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
GlobalDevServicesConfig will be dropped in 3.26 so we should avoid it.

> [!WARNING]
> Note that this requires to set the minimum version to 3.20, so you might have to have a maintenance branch for 3.15 if you want to push new versions supporting 3.15 after this is in.